### PR TITLE
Add support for setting process name when using gunicorn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ USER mapproxy
 ENV PATH /home/mapproxy/.local/bin:$PATH
 
 RUN pip3 --disable-pip-version-check install --user \
-        http://cdn.ftp.openquake.org/wheelhouse/linux/py36/setproctitle-1.1.10-cp36-cp36m-manylinux1_x86_64.whl
+        http://cdn.ftp.openquake.org/wheelhouse/linux/py36/setproctitle-1.1.10-cp36-cp36m-manylinux1_x86_64.whl \
         http://cdn.ftp.openquake.org/wheelhouse/linux/py36/PyYAML-3.12-cp36-cp36m-manylinux1_x86_64.whl \
         http://cdn.ftp.openquake.org/wheelhouse/linux/py36/pyproj-1.9.5.1-cp36-cp36m-manylinux1_x86_64.whl \
         gunicorn \

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ USER mapproxy
 ENV PATH /home/mapproxy/.local/bin:$PATH
 
 RUN pip3 --disable-pip-version-check install --user \
+        http://cdn.ftp.openquake.org/wheelhouse/linux/py36/setproctitle-1.1.10-cp36-cp36m-manylinux1_x86_64.whl
         http://cdn.ftp.openquake.org/wheelhouse/linux/py36/PyYAML-3.12-cp36-cp36m-manylinux1_x86_64.whl \
         http://cdn.ftp.openquake.org/wheelhouse/linux/py36/pyproj-1.9.5.1-cp36-cp36m-manylinux1_x86_64.whl \
         gunicorn \

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ $ docker run -v $(pwd):/io -v d -p 8080:8080 openquake/mapproxy-server
 
 #### Custom configurations via env vars
 
+- `MAPPROXY_NAME`; specify the name of processes spawned by `gunicorn`. Default is `mapproxy`. This feature uses `setproctitle`
 - `MAPPROXY_CPU`: set the number of CPU to be used by `MapProxy`. By default it's the number of available CPU in the container
 - `MAPPROXY_DEV`: run `MapProxy` in the development mode using its development server instead of `gunicorn`
 - `MAPPROXY_WORKER`; specify the worker to be used by `gunicorn`. Default is `gthread`. This option is available only if `MAPPROXY_DEV` is not set

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ $ docker run -v $(pwd):/io -v d -p 8080:8080 openquake/mapproxy-server
 
 #### Custom configurations via env vars
 
-- `MAPPROXY_NAME`; specify the name of processes spawned by `gunicorn`. Default is `mapproxy`. This feature uses `setproctitle`
+- `MAPPROXY_NAME`: specify the name of processes spawned by `gunicorn`. Default is `mapproxy`. This feature uses `setproctitle`
 - `MAPPROXY_CPU`: set the number of CPU to be used by `MapProxy`. By default it's the number of available CPU in the container
 - `MAPPROXY_DEV`: run `MapProxy` in the development mode using its development server instead of `gunicorn`
-- `MAPPROXY_WORKER`; specify the worker to be used by `gunicorn`. Default is `gthread`. This option is available only if `MAPPROXY_DEV` is not set
+- `MAPPROXY_WORKER`: specify the worker to be used by `gunicorn`. Default is `gthread`. This option is available only if `MAPPROXY_DEV` is not set
 
 
 ### Data dir structure

--- a/run-mapproxy.sh
+++ b/run-mapproxy.sh
@@ -21,5 +21,5 @@
 if [ "$MAPPROXY_DEV" ]; then
     exec mapproxy-util serve-multiapp-develop -b :8080 /io/conf
 else
-    exec gunicorn -k ${MAPPROXY_WORKER:-gthread} -t 300 -w ${MAPPROXY_CPU:-`grep -c ^processor /proc/cpuinfo`} -b :8080 config:application --no-sendfile
+    exec gunicorn -n ${MAPPROXY_NAME:-mapproxy} -k ${MAPPROXY_WORKER:-gthread} -t 300 -w ${MAPPROXY_CPU:-`grep -c ^processor /proc/cpuinfo`} -b :8080 config:application --no-sendfile
 fi


### PR DESCRIPTION
Ref: http://docs.gunicorn.org/en/stable/run.html#commonly-used-arguments

Closes #2 